### PR TITLE
Avoid error in projects with a global class Position

### DIFF
--- a/Scripts/Core/VisualElements/GmgTmpRichTextElement.cs
+++ b/Scripts/Core/VisualElements/GmgTmpRichTextElement.cs
@@ -89,7 +89,7 @@ namespace GestureManager.Scripts.Core.VisualElements
         public GmgTmpRichTextElement()
         {
             Add(new TextElement { pickingMode = PickingMode.Ignore, text = "" });
-            Add(_textHolder = new VisualElement { pickingMode = PickingMode.Ignore, style = { position = Position.Absolute } });
+            Add(_textHolder = new VisualElement { pickingMode = PickingMode.Ignore, style = { position = UnityEngine.UIElements.Position.Absolute } });
             style.alignItems = Align.Center;
             _textHolder.style.alignItems = Align.Center;
         }

--- a/Scripts/Editor/Modules/Vrc3/OpenSoundControl/VisualElements/VisualEp.cs
+++ b/Scripts/Editor/Modules/Vrc3/OpenSoundControl/VisualElements/VisualEp.cs
@@ -15,7 +15,7 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3.OpenSoundControl.VisualElem
             VisualElement center;
             TextElement horizontal;
 
-            style.position = Position.Absolute;
+            style.position = UnityEngine.UIElements.Position.Absolute;
             pickingMode = PickingMode.Ignore;
 
             Add(center = VisualEpStyles.Center);
@@ -70,7 +70,7 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3.OpenSoundControl.VisualElem
 
             private static TextElement Create(TextAnchor anchor) => new TextElement
             {
-                style = { color = Color.white, position = Position.Absolute, fontSize = 10, width = VisualEpStyles.InnerSize - 8, marginLeft = 3, unityTextAlign = anchor }
+                style = { color = Color.white, position = UnityEngine.UIElements.Position.Absolute, fontSize = 10, width = VisualEpStyles.InnerSize - 8, marginLeft = 3, unityTextAlign = anchor }
             };
 
             public void SetHeight(float childHeight)

--- a/Scripts/Editor/Modules/Vrc3/OpenSoundControl/VisualElements/VisualEpContainer.cs
+++ b/Scripts/Editor/Modules/Vrc3/OpenSoundControl/VisualElements/VisualEpContainer.cs
@@ -9,7 +9,7 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3.OpenSoundControl.VisualElem
     {
         private readonly Dictionary<EndpointControl, VisualElement> _elements = new Dictionary<EndpointControl, VisualElement>();
 
-        public VisualEpContainer() => style.position = Position.Absolute;
+        public VisualEpContainer() => style.position = UnityEngine.UIElements.Position.Absolute;
 
         protected override bool RenderCondition(ModuleVrc3 module, RadialMenu menu)
         {

--- a/Scripts/Editor/Modules/Vrc3/OpenSoundControl/VisualElements/VisualEpStyles.cs
+++ b/Scripts/Editor/Modules/Vrc3/OpenSoundControl/VisualElements/VisualEpStyles.cs
@@ -36,7 +36,7 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3.OpenSoundControl.VisualElem
         {
             style =
             {
-                position = Position.Absolute,
+                position = UnityEngine.UIElements.Position.Absolute,
                 width = InnerSize,
                 height = InnerSize
             }

--- a/Scripts/Editor/Modules/Vrc3/RadialButtons/Dynamics/VisualRunningElement.cs
+++ b/Scripts/Editor/Modules/Vrc3/RadialButtons/Dynamics/VisualRunningElement.cs
@@ -21,7 +21,7 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3.RadialButtons.Dynamics
                     height = 50,
                     left = -25,
                     top = -25,
-                    position = Position.Absolute,
+                    position = UnityEngine.UIElements.Position.Absolute,
                     backgroundImage = ModuleVrc3Styles.RunningParam
                 }
             });

--- a/Scripts/Editor/Modules/Vrc3/RadialMenu.cs
+++ b/Scripts/Editor/Modules/Vrc3/RadialMenu.cs
@@ -317,16 +317,16 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3
         {
             style.alignItems = Align.Center;
             style.justifyContent = Justify.Center;
-            style.position = Position.Absolute;
+            style.position = UnityEngine.UIElements.Position.Absolute;
             pickingMode = PickingMode.Ignore;
 
             _radial = this.MyAdd(RadialMenuUtility.Prefabs.NewCircle(Size, RadialMenuUtility.Colors.RadialCenter, RadialMenuUtility.Colors.RadialMiddle, RadialMenuUtility.Colors.RadialBorder));
 
-            _borderHolder = _radial.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { position = Position.Absolute } });
-            _radial.MyAdd(RadialMenuUtility.Prefabs.NewCircle((int)InnerSize, RadialMenuUtility.Colors.RadialInner, RadialMenuUtility.Colors.OuterBorder, Position.Absolute));
+            _borderHolder = _radial.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { position = UnityEngine.UIElements.Position.Absolute } });
+            _radial.MyAdd(RadialMenuUtility.Prefabs.NewCircle((int)InnerSize, RadialMenuUtility.Colors.RadialInner, RadialMenuUtility.Colors.OuterBorder, UnityEngine.UIElements.Position.Absolute));
 
-            _dataHolder = _radial.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { position = Position.Absolute } });
-            _puppetHolder = _radial.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { position = Position.Absolute } });
+            _dataHolder = _radial.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { position = UnityEngine.UIElements.Position.Absolute } });
+            _puppetHolder = _radial.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { position = UnityEngine.UIElements.Position.Absolute } });
             _radial.MyAdd(_cursor);
 
             _cursor.SetData(Clamp, ClampReset, (int)(InnerSize / 2f), (int)(Size / 2f), _radial);

--- a/Scripts/Editor/Modules/Vrc3/RadialMenuUtility.cs
+++ b/Scripts/Editor/Modules/Vrc3/RadialMenuUtility.cs
@@ -51,7 +51,7 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3
                         width = size,
                         height = 2,
                         backgroundColor = Colors.RadialBorder,
-                        position = Position.Absolute
+                        position = UnityEngine.UIElements.Position.Absolute
                     }
                 };
             }
@@ -77,7 +77,7 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3
                         left = x - hSize,
                         top = y - hSize,
                         backgroundImage = icon,
-                        position = Position.Absolute
+                        position = UnityEngine.UIElements.Position.Absolute
                     }
                 }.With(new TextElement
                 {
@@ -105,20 +105,20 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3
                         left = -width / 2,
                         top = -height / 2 - 10,
                         backgroundColor = Color.clear,
-                        position = Position.Absolute,
+                        position = UnityEngine.UIElements.Position.Absolute,
                         alignItems = Align.Center,
                         justifyContent = Justify.Center
                     }
                 };
             }
 
-            internal static GmgCircleElement NewCircle(float size, Color color, Color border, Position position = default) => SetCircle(new GmgCircleElement(), size, color, color, border, position);
+            internal static GmgCircleElement NewCircle(float size, Color color, Color border, UnityEngine.UIElements.Position position = default) => SetCircle(new GmgCircleElement(), size, color, color, border, position);
 
-            internal static GmgCircleElement NewCircle(float size, Color centerColor, Color color, Color border, Position position = default) => SetCircle(new GmgCircleElement(), size, centerColor, color, border, position);
+            internal static GmgCircleElement NewCircle(float size, Color centerColor, Color color, Color border, UnityEngine.UIElements.Position position = default) => SetCircle(new GmgCircleElement(), size, centerColor, color, border, position);
 
-            internal static GmgCircleElement SetCircle(GmgCircleElement element, float size, Color color, Color border, Position position = default) => SetCircle(element, size, color, color, border, position);
+            internal static GmgCircleElement SetCircle(GmgCircleElement element, float size, Color color, Color border, UnityEngine.UIElements.Position position = default) => SetCircle(element, size, color, color, border, position);
 
-            private static GmgCircleElement SetCircle(GmgCircleElement element, float size, Color centerColor, Color color, Color border, Position position = default)
+            private static GmgCircleElement SetCircle(GmgCircleElement element, float size, Color centerColor, Color color, Color border, UnityEngine.UIElements.Position position = default)
             {
                 element.BorderWidth = 2;
                 element.VertexColor = color;
@@ -132,12 +132,12 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3
                 return element;
             }
 
-            internal static VisualElement NewRadialText(out TextElement text, int top, Position position = default)
+            internal static VisualElement NewRadialText(out TextElement text, int top, UnityEngine.UIElements.Position position = default)
             {
                 return SetRadialText(new VisualElement(), out text, top, position);
             }
 
-            internal static VisualElement SetRadialText(VisualElement element, out TextElement text, int top, Position position = default)
+            internal static VisualElement SetRadialText(VisualElement element, out TextElement text, int top, UnityEngine.UIElements.Position position = default)
             {
                 element.style.width = 50;
                 element.style.height = 20;
@@ -169,7 +169,7 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3
                         left = 60,
                         top = 50,
                         backgroundColor = Colors.SubIcon,
-                        position = Position.Absolute,
+                        position = UnityEngine.UIElements.Position.Absolute,
                         justifyContent = Justify.Center,
                         alignItems = Align.Center
                     }

--- a/Scripts/Editor/Modules/Vrc3/RadialPuppets/Base/BaseAxisPuppet.cs
+++ b/Scripts/Editor/Modules/Vrc3/RadialPuppets/Base/BaseAxisPuppet.cs
@@ -13,19 +13,19 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3.RadialPuppets.Base
 
         protected BaseAxisPuppet(RadialMenuControl control) : base(140, control)
         {
-            var holder = this.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { position = Position.Absolute } });
+            var holder = this.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { position = UnityEngine.UIElements.Position.Absolute } });
             holder.Add(RadialMenuUtility.Prefabs.NewBorder(70, 45));
             holder.Add(RadialMenuUtility.Prefabs.NewBorder(70, 135));
             holder.Add(RadialMenuUtility.Prefabs.NewBorder(70, 225));
             holder.Add(RadialMenuUtility.Prefabs.NewBorder(70, 315));
-            Add(RadialMenuUtility.Prefabs.NewCircle(65, RadialMenuUtility.Colors.RadialInner, RadialMenuUtility.Colors.OuterBorder, Position.Absolute));
+            Add(RadialMenuUtility.Prefabs.NewCircle(65, RadialMenuUtility.Colors.RadialInner, RadialMenuUtility.Colors.OuterBorder, UnityEngine.UIElements.Position.Absolute));
             _labels = control.GetSubLabels();
         }
 
         public override void AfterCursor()
         {
             const int v = 50;
-            var holder = this.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { position = Position.Absolute } });
+            var holder = this.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { position = UnityEngine.UIElements.Position.Absolute } });
             holder.Add(RadialMenuUtility.Prefabs.NewIconText(0, -v, 24, LabelIcon(0, ModuleVrc3Styles.AxisUp), LabelText(0)));
             holder.Add(RadialMenuUtility.Prefabs.NewIconText(v, 0, 24, LabelIcon(1, ModuleVrc3Styles.AxisRight), LabelText(1)));
             holder.Add(RadialMenuUtility.Prefabs.NewIconText(0, v, 24, LabelIcon(2, ModuleVrc3Styles.AxisDown), LabelText(2)));

--- a/Scripts/Editor/Modules/Vrc3/RadialPuppets/RadialPuppet.cs
+++ b/Scripts/Editor/Modules/Vrc3/RadialPuppets/RadialPuppet.cs
@@ -18,9 +18,9 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3.RadialPuppets
 
         public RadialPuppet(RadialMenuControl control) : base(100, control)
         {
-            _progress = this.MyAdd(RadialMenuUtility.Prefabs.NewCircle(96, RadialMenuUtility.Colors.ProgressRadial, RadialMenuUtility.Colors.ProgressRadial, Position.Absolute));
-            Add(RadialMenuUtility.Prefabs.NewCircle(65, RadialMenuUtility.Colors.RadialInner, RadialMenuUtility.Colors.OuterBorder, Position.Absolute));
-            Add(RadialMenuUtility.Prefabs.NewRadialText(out _text, 0, Position.Absolute));
+            _progress = this.MyAdd(RadialMenuUtility.Prefabs.NewCircle(96, RadialMenuUtility.Colors.ProgressRadial, RadialMenuUtility.Colors.ProgressRadial, UnityEngine.UIElements.Position.Absolute));
+            Add(RadialMenuUtility.Prefabs.NewCircle(65, RadialMenuUtility.Colors.RadialInner, RadialMenuUtility.Colors.OuterBorder, UnityEngine.UIElements.Position.Absolute));
+            Add(RadialMenuUtility.Prefabs.NewRadialText(out _text, 0, UnityEngine.UIElements.Position.Absolute));
             _arrow = this.MyAdd(GenerateArrow());
 
             ShowValue(Get);
@@ -66,7 +66,7 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3.RadialPuppets
 
         private static VisualElement GenerateArrow()
         {
-            var container = new VisualElement { pickingMode = PickingMode.Ignore, style = { position = Position.Absolute } };
+            var container = new VisualElement { pickingMode = PickingMode.Ignore, style = { position = UnityEngine.UIElements.Position.Absolute } };
             var element = container.MyAdd(new VisualElement
             {
                 pickingMode = PickingMode.Ignore,
@@ -76,7 +76,7 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3.RadialPuppets
                     height = 20,
                     backgroundColor = RadialMenuUtility.Colors.ProgressRadial,
                     top = -65,
-                    position = Position.Absolute
+                    position = UnityEngine.UIElements.Position.Absolute
                 }
             }).MyBorder(2f, 0f, RadialMenuUtility.Colors.ProgressBorder);
             element.transform.rotation = Quaternion.Euler(0, 0, 45);

--- a/Scripts/Editor/Modules/Vrc3/Vrc3WeightSlider.cs
+++ b/Scripts/Editor/Modules/Vrc3/Vrc3WeightSlider.cs
@@ -35,7 +35,7 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3
             _target = target;
 
             style.justifyContent = Justify.Center;
-            style.position = Position.Absolute;
+            style.position = UnityEngine.UIElements.Position.Absolute;
             pickingMode = PickingMode.Ignore;
 
             CreateWeightController();
@@ -43,12 +43,12 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3
 
         private void CreateWeightController()
         {
-            _slider = this.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { opacity = 0f, position = Position.Absolute, justifyContent = Justify.Center } });
-            _right = _slider.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { backgroundColor = Color.gray, height = 10, position = Position.Absolute, right = 0 } }).MyBorder(1, 5, Color.black);
-            _left = _slider.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { backgroundColor = RadialMenuUtility.Colors.ProgressRadial, height = 10, width = 10, position = Position.Absolute, left = 0 } }).MyBorder(1, 5, Color.black);
-            _dot = _slider.MyAdd(RadialMenuUtility.Prefabs.NewCircle(16, RadialMenuUtility.Colors.RadialCenter, RadialMenuUtility.Colors.RadialMiddle, RadialMenuUtility.Colors.RadialBorder, Position.Absolute));
+            _slider = this.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { opacity = 0f, position = UnityEngine.UIElements.Position.Absolute, justifyContent = Justify.Center } });
+            _right = _slider.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { backgroundColor = Color.gray, height = 10, position = UnityEngine.UIElements.Position.Absolute, right = 0 } }).MyBorder(1, 5, Color.black);
+            _left = _slider.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { backgroundColor = RadialMenuUtility.Colors.ProgressRadial, height = 10, width = 10, position = UnityEngine.UIElements.Position.Absolute, left = 0 } }).MyBorder(1, 5, Color.black);
+            _dot = _slider.MyAdd(RadialMenuUtility.Prefabs.NewCircle(16, RadialMenuUtility.Colors.RadialCenter, RadialMenuUtility.Colors.RadialMiddle, RadialMenuUtility.Colors.RadialBorder, UnityEngine.UIElements.Position.Absolute));
 
-            _textHolder = this.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { opacity = 1f, position = Position.Absolute, justifyContent = Justify.Center, unityTextAlign = TextAnchor.MiddleCenter, alignItems = Align.Center, flexDirection = FlexDirection.Row } });
+            _textHolder = this.MyAdd(new VisualElement { pickingMode = PickingMode.Ignore, style = { opacity = 1f, position = UnityEngine.UIElements.Position.Absolute, justifyContent = Justify.Center, unityTextAlign = TextAnchor.MiddleCenter, alignItems = Align.Center, flexDirection = FlexDirection.Row } });
             _textHolder.MyAdd(new TextElement { pickingMode = PickingMode.Ignore, text = "Weight: ", style = { fontSize = 12, height = 15 } });
             _textWeight = _textHolder.MyAdd(new TextElement { pickingMode = PickingMode.Ignore, text = "100%", style = { fontSize = 15, color = RadialMenuUtility.Colors.ProgressRadial, height = 15 } });
         }


### PR DESCRIPTION
Some users have been reporting this error for a few months since using the version of GestureManager bundled in AV3Emulator:

![error CS0117: 'Position' does not contain a definition for 'Absolute'](https://user-images.githubusercontent.com/39946030/165143074-d746b1c6-f3d3-4498-8690-6265345f05e5.png)

I believe some popular package has a "class Position" somewhere, which is causing the conflict.

To workaround, I have replaced all Position with the full namespace UnityEngine.UIElements.Position.