### PR TITLE
Fixes

### DIFF
--- a/Scripts/Editor/Modules/Vrc3/ModuleVrc3.cs
+++ b/Scripts/Editor/Modules/Vrc3/ModuleVrc3.cs
@@ -100,9 +100,22 @@ namespace GestureManager.Scripts.Editor.Modules.Vrc3
             if (_broken) return;
             OscModule.Update();
             _avatarTools.OnUpdate(this);
-            if (DummyMode == null && _layers.Any(IsBroken)) OnBrokenSimulation();
-            if (DummyMode != null && (!DummyMode.Avatar || Avatar.activeSelf)) Dummy.ShutDown();
-            foreach (var pair in _layers) pair.Value.Weight.Update();
+            if (DummyMode == null && IsAnyBroken(_layers)) 
+                OnBrokenSimulation();
+            if (DummyMode != null && (!DummyMode.Avatar || Avatar.activeSelf)) 
+                Dummy.ShutDown();
+            foreach (var pair in _layers) 
+                pair.Value.Weight.Update();
+        }
+
+        private bool IsAnyBroken(Dictionary<VRCAvatarDescriptor.AnimLayerType, LayerData> _layers) 
+        {
+            foreach (var item in _layers)
+            {
+                if (!item.Value.Empty && item.Value.Playable.GetInput(0).IsNull())
+                    return true;
+            }
+            return false;
         }
 
         public override void LateUpdate() => _avatarTools.OnLateUpdate(this);


### PR DESCRIPTION
Fix "Collection was modified" error by converting the Dictionary to a List and iterating it with a for loop
Add check for layer index being in range for the playable ("Invalid Layer Index" error)
No more GC Alloc every frame