### PR TITLE
Mandatory Changes to support SDK 3.2.0 and future versions.

### DIFF
--- a/Scripts/Editor/Modules/Vrc3/DummyModes/Vrc3DummyMode.cs
+++ b/Scripts/Editor/Modules/Vrc3/DummyModes/Vrc3DummyMode.cs
@@ -1,6 +1,7 @@
 ﻿#if VRC_SDK_VRCSDK3
 using UnityEditor;
 using UnityEngine;
+using VRC.Core;
 
 namespace BlackStartX.GestureManager.Editor.Modules.Vrc3.DummyModes
 {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name" : "vrchat.blackstartx.gesture-manager",
 	"displayName" : "Gesture Manager",
-	"version" : "3.8.3",
+	"version" : "3.8.4",
 	"unity" : "2019.4",
 	"description" : "A tool that will help you preview your VRChat Avatar animation directly in Unity.",
 	"type" : "tool",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
 		"Assets\\GestureManager" : "73dec07c46a7d41409b0c389860fb28e"
 	},
 	"vpmDependencies" : {
-		"com.vrchat.avatars" : ">=3.2.0"
+		"com.vrchat.avatars" : ">=3.1.13"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
 		"Assets\\GestureManager" : "73dec07c46a7d41409b0c389860fb28e"
 	},
 	"vpmDependencies" : {
-		"com.vrchat.avatars" : "3.1.x"
+		"com.vrchat.avatars" : ">=3.2.0"
 	}
 }


### PR DESCRIPTION
As you will see here, VRChat is moving the extension method used in `Vrc3DummyMode.cs` to the VRC.Core namespace. The old method used will be fully deprecated in the near future, so I have future-proofed this script to make sure it works with the new namespace.

In addition, the `vpmDependencies` had to be updated in order for it to allow SDK 3.2.0 and all future versions to work with Gesture Manager. So that has been done as well. You will see I added `>=` to it. Following the Semantic Versioning scheme, this argument allows ANY future versions from this point on to work with Gesture Manager. So you will no longer have to update this as often.

**These changes will prevent Gesture Manager from breaking on SDK 3.2.0 once it's released to the Public.**

Thank you. Please let me know if there is anything else I may have missed.