### PR TITLE
Fixup assembly reference and warning for SDK 3.2.0

### DIFF
--- a/Scripts/Editor/Modules/Vrc3/DummyModes/Vrc3DummyMode.cs
+++ b/Scripts/Editor/Modules/Vrc3/DummyModes/Vrc3DummyMode.cs
@@ -26,7 +26,7 @@ namespace BlackStartX.GestureManager.Editor.Modules.Vrc3.DummyModes
             if (!keepPose) Module.ForgetAvatar();
             if (!Avatar) Avatar = Object.Instantiate(Module.Avatar);
             if (keepPose) Module.ForgetAvatar();
-            Animator = Avatar.GetOrAddComponent<Animator>();
+            Animator = VRC.Core.ExtensionMethods.GetOrAddComponent<Animator>(Avatar);
             Avatar.name = Module.Avatar.name + " " + prefix;
             Module.Avatar.SetActive(false);
             Module.Avatar.hideFlags = HideFlags.HideInHierarchy | HideFlags.HideInInspector;

--- a/Scripts/Editor/vrchat.blackstartx.gesture-manager.editor.asmdef
+++ b/Scripts/Editor/vrchat.blackstartx.gesture-manager.editor.asmdef
@@ -2,7 +2,8 @@
     "name": "vrchat.blackstartx.gesture-manager.editor",
     "rootNamespace": "BlackStartX.GestureManager",
     "references": [
-        "GUID:184316a0752f3c74fbd758a2fb0f0d46"
+        "GUID:184316a0752f3c74fbd758a2fb0f0d46",
+        "GUID:5718fb738711cd34ea54e9553040911d"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
This adds `VRC.SDK3A` to `vrchat.blackstartx.gesture-manager.editor` since `PhysBoneGrabHelper` moved to that assembly. The existing editor assembly already references the gesture-manager runtime one, so I think it's fine to add one to the SDK's runtime one too.

Fix a warning too, while at it. This runs with no warnings or errors in SDK 3.2.0 now. Smoke-tested on my personal avatar project.

Hope this helps!
~ pi ✨ 