### PR TITLE
Fix Debug Window Width

### DIFF
--- a/Scripts/Editor/Modules/Vrc3/ModuleVrc3.cs
+++ b/Scripts/Editor/Modules/Vrc3/ModuleVrc3.cs
@@ -430,7 +430,7 @@ namespace BlackStartX.GestureManager.Editor.Modules.Vrc3
                     return;
             }
 
-            DebugContext(root, holder, menu.DebugToolBar.Selected, Screen.width - 60, false);
+            DebugContext(root, holder, menu.DebugToolBar.Selected, EditorGUIUtility.currentViewWidth - 60, false);
             GUILayout.Space(4);
             GmgLayoutHelper.Divisor(1);
         }

--- a/Scripts/Editor/Modules/Vrc3/Vrc3Debug/Avatar/Vrc3AvatarDebugWindow.cs
+++ b/Scripts/Editor/Modules/Vrc3/Vrc3Debug/Avatar/Vrc3AvatarDebugWindow.cs
@@ -45,7 +45,7 @@ namespace BlackStartX.GestureManager.Editor.Modules.Vrc3.Vrc3Debug.Avatar
         private void DebugGUI()
         {
             GUILayout.Label("Gesture Manager - Avatar Debug Window", GestureManagerStyles.Header);
-            var isFullScreen = Screen.width > 1279;
+            var isFullScreen = EditorGUIUtility.currentViewWidth > 1279;
             if (!isFullScreen) _source.DebugToolBar = Static.DebugToolbar(_source.DebugToolBar);
             _scroll = GUILayout.BeginScrollView(_scroll);
             _source.DebugContext(rootVisualElement, null, 0, EditorGUIUtility.currentViewWidth - 60, isFullScreen);

--- a/Scripts/Editor/Modules/Vrc3/Vrc3Debug/Avatar/Vrc3AvatarDebugWindow.cs
+++ b/Scripts/Editor/Modules/Vrc3/Vrc3Debug/Avatar/Vrc3AvatarDebugWindow.cs
@@ -48,7 +48,7 @@ namespace BlackStartX.GestureManager.Editor.Modules.Vrc3.Vrc3Debug.Avatar
             var isFullScreen = Screen.width > 1279;
             if (!isFullScreen) _source.DebugToolBar = Static.DebugToolbar(_source.DebugToolBar);
             _scroll = GUILayout.BeginScrollView(_scroll);
-            _source.DebugContext(rootVisualElement, null, 0, Screen.width - 60, isFullScreen);
+            _source.DebugContext(rootVisualElement, null, 0, EditorGUIUtility.currentViewWidth - 60, isFullScreen);
             GUILayout.EndScrollView();
         }
 


### PR DESCRIPTION
# Motivation
- As documented in #29, debug window does not respect the width of its editor pane on high DPI displays which use a scale factor greater than 1.0.
- Fix is rather simple: To replace 2 instances of `Screen.width` with `EditorGUIUtility.currentViewWidth`, as documented.
- **My code has been tested and confirmed working.**
- Additional testing may be needed.

# Testing Environment
- MacBook Air M2
- 24GB RAM
- Unity 2019.4.31f
- Gesture Manager 3.8