### PR TITLE
chore: use name instead of guid in asmdef to workaround unity bug

### DIFF
--- a/Scripts/Editor/vrchat.blackstartx.gesture-manager.editor.asmdef
+++ b/Scripts/Editor/vrchat.blackstartx.gesture-manager.editor.asmdef
@@ -2,8 +2,8 @@
     "name": "vrchat.blackstartx.gesture-manager.editor",
     "rootNamespace": "BlackStartX.GestureManager.Editor",
     "references": [
-        "GUID:184316a0752f3c74fbd758a2fb0f0d46",
-        "GUID:5718fb738711cd34ea54e9553040911d"
+        "vrchat.blackstartx.gesture-manager",
+        "VRC.SDK3A"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
Fixes #36 