### PR TITLE
Added Earmuffs to Radial Menu to test Earmuffs Mode Parameter

### DIFF
--- a/Scripts/Editor/Modules/Vrc3/RadialMenu.cs
+++ b/Scripts/Editor/Modules/Vrc3/RadialMenu.cs
@@ -208,6 +208,7 @@ namespace BlackStartX.GestureManager.Editor.Modules.Vrc3
                 RadialMenuUtility.Buttons.ToggleFromParam(this, "IsLocal", GetParam(Vrc3DefaultParams.IsLocal)),
                 RadialMenuUtility.Buttons.RadialFromParam(this, "Gesture\nRight Weight", GetParam(Vrc3DefaultParams.GestureRightWeight)),
                 RadialMenuUtility.Buttons.ToggleFromParam(this, "MuteSelf", GetParam(Vrc3DefaultParams.MuteSelf)),
+                RadialMenuUtility.Buttons.ToggleFromParam(this, "Earmuffs", GetParam(Vrc3DefaultParams.Earmuffs)),
                 RadialMenuUtility.Buttons.RadialFromParam(this, "Gesture\nLeft Weight", GetParam(Vrc3DefaultParams.GestureLeftWeight)),
                 RadialMenuUtility.Buttons.ToggleFromParam(this, "InStation", GetParam(Vrc3DefaultParams.InStation))
             });

--- a/Scripts/Editor/Modules/Vrc3/Vrc3DefaultParams.cs
+++ b/Scripts/Editor/Modules/Vrc3/Vrc3DefaultParams.cs
@@ -24,6 +24,7 @@ namespace BlackStartX.GestureManager.Editor.Modules.Vrc3
         internal const string InStation = "InStation";
         internal const string Grounded = "Grounded";
         internal const string MuteSelf = "MuteSelf";
+        internal const string Earmuffs = "Earmuffs";
         internal const string Upright = "Upright";
         internal const string IsLocal = "IsLocal";
         internal const string Seated = "Seated";
@@ -35,7 +36,6 @@ namespace BlackStartX.GestureManager.Editor.Modules.Vrc3
         private const string VrcFaceBlendV = "VRCFaceBlendV";
         private const string VrcEmote = "VRCEmote";
         private const string AngularY = "AngularY";
-        private const string Earmuffs = "Earmuffs";
         private const string Voice = "Voice";
 
         public static IEnumerable<(string name, AnimatorControllerParameterType type)> Parameters => new[]


### PR DESCRIPTION
Hello there!

I recently discovered that for some reason, I could not test the default VRChat Parameter `Earmuffs` using the Radial Menu on the Emulator. **So... I have finally added that in!**

# Introducing "Earmuffs" in the Radial Menu!

I've placed it into the category that makes the most sense... under `Options -> Extras` in the Radial Menu. You will also notice that I re-sorted it to be a bit more visually balanced, making `Gesture Left Weight` and `Gesture Right Weight` appear equally across each other next to the "Back" button. This was done because I added the Earmuffs Parameter to test the toggle for Earmuffs Mode.

### Here's the Reference point for using the "Earmuffs" Parameter:
The `Earmuffs` Parameter is a Default Animator Parameter, a `bool`, that outputs `true` when the Player turns on Earmuffs Mode in their VRChat Settings. Outputs `false` if it's off. This has since been introduced as a default Parameter so that VRChat Creators can have their Animators do things whenever Earmuffs Mode was toggled in-game through the VRChat Settings. Since it's a Default Synced Parameter, remote users can see it as well. Documentation Reference: https://creators.vrchat.com/avatars/animator-parameters/#parameters