### PR TITLE
Fixed Documentation URLs

### DIFF
--- a/Scripts/Editor/Modules/Vrc3/RadialMenu.cs
+++ b/Scripts/Editor/Modules/Vrc3/RadialMenu.cs
@@ -29,7 +29,7 @@ namespace BlackStartX.GestureManager.Editor.Modules.Vrc3
         private const float Clamp = Size / 3;
         private const float ClampReset = Size / 1.7f;
 
-        private const string TrackingDocumentationUrl = "https://docs.vrchat.com/docs/animator-parameters#trackingtype-parameter";
+        private const string TrackingDocumentationUrl = "https://creators.vrchat.com/avatars/animator-parameters/#trackingtype-parameter";
 
         private Vector2 MousePosition()
         {


### PR DESCRIPTION
This is just a simple bug fix to ensure the new documentation URLs are being used when referenced in the Emulator, as VRChat is now using `creators.vrchat.com` instead of `docs.vrchat.com`.