### PR TITLE
No longer force maximum version of SDK.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
 		"Assets\\GestureManager" : "73dec07c46a7d41409b0c389860fb28e"
 	},
 	"vpmDependencies" : {
-		"com.vrchat.avatars" : ">=3.5.2 < 3.7.X"
+		"com.vrchat.avatars" : "^3.5.2"
 	}
 }


### PR DESCRIPTION
For the past few SDK updates, there hasn't ever been any changes that broke Gesture Manager in any way whatsoever. Because of this, I think it's very unnecessary to force a maximum version of the SDK.

To follow in Av3Emulator's footsteps, this PR changes the `"com.vrchat.avatars"` vpmDependency to `"^3.5.2"`, which introduces the `^` argument. This makes Gesture Emulator only require a minimum of SDK 3.5.2, and will support all future versions of the SDK until v4.0.0 (if it even happens).

We both know it's a bit tiring for everyone to have to update a Curated Package every single time the SDK makes a Minor Upgrade. So, this PR intends to make it easier for both yourself and everyone that Gesture Manager works no matter what, by avoiding the awful "Incompatible Version" warning in the Creator Companion.

I highly recommend you introduce this change for the next update, especially for those who use Av3Emulator with Gesture Manager for your Radial Menu. ^^